### PR TITLE
Add statsd metrics, simplify test data

### DIFF
--- a/src/pkg/statsd/statsd.go
+++ b/src/pkg/statsd/statsd.go
@@ -86,7 +86,7 @@ func Gauge(metric string, n int) {
 }
 
 func puke(err error) {
-  if os.Getenv("TESTMOD") == "0" {
+  if os.Getenv("TESTMODE") == "" {
     logrus.WithField("error", err).Warn("couldn't submit event to statsd")
   }
 }


### PR DESCRIPTION
- Add statds metrics for amount of containers/images before cleanup and counters for each succesfull removal
- Simplify test data to only have what is needed for the test

@andremedeiros 
