### PR TITLE
Make container deletion use the exited date rather than created

### DIFF
--- a/src/pkg/gc/gc_test.go
+++ b/src/pkg/gc/gc_test.go
@@ -2,7 +2,6 @@ package gc
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,50 +14,9 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	logrustest "github.com/Sirupsen/logrus/hooks/test"
-	"github.com/fsouza/go-dockerclient"
 	udp "github.com/n1koo/go-udp-testing"
 	"github.com/stretchr/testify/assert"
 )
-
-type FakeRoundTripper struct {
-	message  string
-	status   int
-	header   map[string]string
-	requests []*http.Request
-}
-
-func (rt *FakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	body := strings.NewReader(rt.message)
-	rt.requests = append(rt.requests, r)
-	res := &http.Response{
-		StatusCode: rt.status,
-		Body:       ioutil.NopCloser(body),
-		Header:     make(http.Header),
-	}
-	for k, v := range rt.header {
-		res.Header.Set(k, v)
-	}
-	return res, nil
-}
-
-func (rt *FakeRoundTripper) Reset() {
-	rt.requests = nil
-}
-
-func dummyDockerServer() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, "ok")
-	}))
-}
-
-func newTestClient(rt *FakeRoundTripper) *docker.Client {
-	endpoint := "http://localhost:4243"
-	client, _ := docker.NewClient(endpoint)
-	client.HTTPClient = &http.Client{Transport: rt}
-	return client
-}
 
 type FakeDiskSpaceFetcher struct {
 	counter int
@@ -72,8 +30,132 @@ func (d *FakeDiskSpaceFetcher) GetUsedDiskSpaceInPercents() (int, error) {
 	return d.counter, nil
 }
 
+var responseIndices = map[string]int{}
+
+type testResponseMap map[string][]string
+
+func testServer(responses testResponseMap) *httptest.Server {
+	mux := http.NewServeMux()
+
+	for path, responses := range responses {
+		// Variable shadowing.
+		_responses := responses
+
+		fun := func(w http.ResponseWriter, r *http.Request) {
+			idx := responseIndices[path]
+			response := _responses[idx%len(_responses)]
+			responseIndices[path] = idx + 1
+
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(response))
+		}
+
+		mux.Handle(path, http.HandlerFunc(fun))
+	}
+
+	server := httptest.NewServer(mux)
+	return server
+}
+
+func generateFourTestImages() string {
+	//Generate 4 images which 2 have been exited in past minute and two havent
+	timeNow := time.Now()
+	threeSecondsOld := timeNow.Add(-3 * time.Second)
+	fiveMinutesOld := timeNow.Add(-5 * time.Minute)
+	twelweHoursOld := timeNow.Add(-12 * time.Hour)
+	dayOld := timeNow.Add(-24 * time.Hour)
+
+	idsAndDatesMap := make(map[string]string)
+	idsAndDatesMap["8dfafdbc3a40"] = strconv.FormatInt(timeNow.Unix(), 10)
+	idsAndDatesMap["9cd87474be90"] = strconv.FormatInt(threeSecondsOld.Unix(), 10)
+	idsAndDatesMap["3176a2479c92"] = strconv.FormatInt(fiveMinutesOld.Unix(), 10)
+	idsAndDatesMap["4cb07b47f9fb"] = strconv.FormatInt(twelweHoursOld.Unix(), 10)
+	idsAndDatesMap["5c76a2479c92"] = strconv.FormatInt(dayOld.Unix(), 10)
+
+	var imageList []string
+
+	for id, date := range idsAndDatesMap {
+		imageListInfo := `
+     {
+             "Id":"` + id + `",
+             "Created":` + date + `
+     }`
+		imageList = append(imageList, imageListInfo)
+	}
+
+	imageListAsJson := strings.Join(imageList[:], ",")
+	imageListAsJson = `[` + imageListAsJson + "\n" + `  ]`
+
+	return imageListAsJson
+}
+
+func generateFourTestContainers() (string, map[string]string) {
+	//Generate 4 containers of which 2 have been exited in past minute and two havent
+	timeNow := time.Now()
+	fiveMinutesOld := timeNow.Add(-3 * time.Second)
+	twelweHoursOld := timeNow.Add(-12 * time.Hour)
+	weekOld := timeNow.Add(-7 * 24 * time.Hour)
+
+	idsAndDatesMap := make(map[string]string)
+	idsAndDatesMap["8dfafdbc3a40"] = timeNow.Format(time.RFC3339)
+	idsAndDatesMap["9cd87474be90"] = fiveMinutesOld.Format(time.RFC3339)
+	idsAndDatesMap["3176a2479c92"] = twelweHoursOld.Format(time.RFC3339)
+	idsAndDatesMap["4cb07b47f9fb"] = weekOld.Format(time.RFC3339)
+
+	var containerList []string
+	containerListWithFullData := make(map[string]string)
+
+	for id, date := range idsAndDatesMap {
+		containerListInfo := `
+     {
+             "Id":"` + id + `"
+     }`
+		containerList = append(containerList, containerListInfo)
+
+		containerFullInfo := `
+     {
+             "Id":"` + id + `",
+                   "State": {
+                     "Running": false,
+                     "FinishedAt": "` + date + `"
+                   }
+    }`
+		containerListWithFullData[id] = containerFullInfo
+
+	}
+
+	containerListAsJson := strings.Join(containerList[:], ",")
+	containerListAsJson = `[` + containerListAsJson + "\n" + `  ]`
+
+	return containerListAsJson, containerListWithFullData
+}
+
+func generateTestData() testResponseMap {
+	imageListAsJson := generateFourTestImages()
+	containerListAsJson, containerListWithFullData := generateFourTestContainers()
+
+	responses := testResponseMap{
+		"/_ping":           []string{`OK`},
+		"/images/":         []string{`OK`},
+		"/images/json":     []string{imageListAsJson},
+		"/containers/json": []string{containerListAsJson},
+	}
+
+	for id, data := range containerListWithFullData {
+		responses["/containers/"+id+"/json"] = []string{data}
+		responses["/containers/"+id+""] = []string{"ok"}
+	}
+
+	return responses
+}
+
 func TestStartDockerClient(t *testing.T) {
-	server := dummyDockerServer()
+	responses := map[string][]string{
+		"/_ping": []string{"OK"},
+	}
+
+	server := testServer(responses)
 	defer server.Close()
 
 	endpoint := server.URL
@@ -105,32 +187,13 @@ func TestFailIfDockerNotAvailable(t *testing.T) {
 }
 
 func TestCleanImages(t *testing.T) {
-	timeNow := time.Now()
-	fiveMinutesOld := timeNow.Add(-5 * time.Minute)
-	twelweHoursOld := timeNow.Add(-12 * time.Hour)
-	weekOld := timeNow.Add(-7 * 24 * time.Hour)
 
-	body := `[
-     {
-             "Id":"b750fe79269d",
-             "Created":` + strconv.FormatInt(timeNow.Unix(), 10) + `
-     },
-     {
-             "Id":"b750fe79269d",
-             "Created":` + strconv.FormatInt(fiveMinutesOld.Unix(), 10) + `
-     },
-     {
-             "Id": "8dbd9e392a964c",
-             "Created": ` + strconv.FormatInt(twelweHoursOld.Unix(), 10) + `
-      },
-      {
-             "Id": "b750fe79269d2e",
-             "Created": ` + strconv.FormatInt(weekOld.Unix(), 10) + `
-      }
-]`
-
-	Client = newTestClient(&FakeRoundTripper{message: body, status: http.StatusOK})
 	keepLastImages := 10 * time.Hour // Keep images that have been created in the last 10 hours
+	server := testServer(generateTestData())
+	defer server.Close()
+
+	Client = nil
+	StartDockerClient(server.URL)
 
 	_, hook := logrustest.NewNullLogger()
 	log.AddHook(hook)
@@ -140,38 +203,18 @@ func TestCleanImages(t *testing.T) {
 	// Verify 2 images (12h + week old) were cleaned
 	assert.Equal(t, 2, len(hook.Entries), "we should be removing two images")
 	assert.Equal(t, log.InfoLevel, hook.Entries[1].Level, "all image removal messages should log on Info level")
-	assert.Equal(t, "Trying to delete image: 8dbd9e392a964c", hook.Entries[0].Message, "expected to delete 8dbd9e392a964c")
+	assert.Equal(t, "Trying to delete image: 4cb07b47f9fb", hook.Entries[0].Message, "expected to delete 4cb07b47f9fb")
 	assert.Equal(t, log.InfoLevel, hook.Entries[0].Level, "all image removal messages should log on Info level")
-	assert.Equal(t, "Trying to delete image: b750fe79269d2e", hook.Entries[1].Message, "expected to delete 8dbd9e392a964c")
+	assert.Equal(t, "Trying to delete image: 5c76a2479c92", hook.Entries[1].Message, "expected to delete 5c76a2479c92")
 }
 
 func TestCleanContainers(t *testing.T) {
-	timeNow := time.Now()
-	fiveSecondsOld := timeNow.Add(-5 * time.Second)
-	fiveMinutesOld := timeNow.Add(-5 * time.Minute)
-	twelweHoursOld := timeNow.Add(-12 * time.Hour)
-
-	body := `[
-     {
-             "Id": "8dfafdbc3a40",
-             "Created": ` + strconv.FormatInt(timeNow.Unix(), 10) + `
-     },
-     {
-             "Id": "9cd87474be90",
-             "Created": ` + strconv.FormatInt(fiveSecondsOld.Unix(), 10) + `
-     },
-     {
-             "Id": "3176a2479c92",
-             "Created": ` + strconv.FormatInt(fiveMinutesOld.Unix(), 10) + `
-     },
-     {
-             "Id": "4cb07b47f9fb",
-             "Created": ` + strconv.FormatInt(twelweHoursOld.Unix(), 10) + `
-     }
-]`
-
-	Client = newTestClient(&FakeRoundTripper{message: body, status: http.StatusOK})
 	keepLastContainers := 1 * time.Minute // Keep containers that have exited in past 59seconds
+
+	server := testServer(generateTestData())
+	defer server.Close()
+
+	StartDockerClient(server.URL)
 
 	_, hook := logrustest.NewNullLogger()
 	log.AddHook(hook)
@@ -190,50 +233,43 @@ func TestContinuousGC(t *testing.T) {
 	_, hook := logrustest.NewNullLogger()
 	log.AddHook(hook)
 
-	keepLastContainers := 10 * time.Second // Keep containers for 5s
-	keepLastImages := 10 * time.Second     // Keep images for 5s
+	keepLastContainers := 10 * time.Second // Keep containers for 10s
+	keepLastImages := 10 * time.Second     // Keep images for 10s
 
 	var interval uint64 = 3 // interval for cron run
 
-	timeNow := time.Now()
-	threeSecondsOld := timeNow.Add(-3 * time.Second)
+	server := testServer(generateTestData())
+	defer server.Close()
 
-	// Two entities with one being created right now, one is three seconds old
-	body := `[
-     {
-             "Id": "8dfafdbc3a40",
-             "Created": ` + strconv.FormatInt(timeNow.Unix(), 10) + `
-     },
-     {
-             "Id": "9cd87474be90",
-             "Created": ` + strconv.FormatInt(threeSecondsOld.Unix(), 10) + `
-     }
-  ]`
+	Client = nil
+	StartDockerClient(server.URL)
 
-	Client = newTestClient(&FakeRoundTripper{message: body, status: http.StatusOK})
 	ContinuousGC(interval, GCPolicy{KeepLastContainers: keepLastContainers, KeepLastImages: keepLastImages})
 	// Wait for three runs
 	time.Sleep(10 * time.Second)
 	StopGC()
 
 	// Assert all that is expected to happen during that 10s period
-	assert.Equal(t, 10, len(hook.Entries), "We see 10 message")
+	assert.Equal(t, 25, len(hook.Entries), "We see 25 message")
 	assert.Equal(t, log.InfoLevel, hook.Entries[0].Level, "We should use see Info about starting continuous GC")
 	assert.Equal(t, "Continous run started in timebased mode with interval (in seconds): 3", hook.Entries[0].Message, "report start of GC")
 	assert.Equal(t, "Cleaning all images/containers", hook.Entries[1].Message, "report start of first cleanup")
-	assert.Equal(t, "Cleaning all images/containers", hook.Entries[2].Message, "report start of second cleanup")
-	assert.Equal(t, "Trying to delete container: 9cd87474be90", hook.Entries[3].Message, "expected to delete the 3sec old container on second run")
-	assert.Equal(t, "Trying to delete image: 9cd87474be90", hook.Entries[4].Message, "expected to delete the 3sec old image on second run")
-	assert.Equal(t, "Cleaning all images/containers", hook.Entries[5].Message, "Start of third run")
-	assert.Equal(t, "Trying to delete container: 8dfafdbc3a40", hook.Entries[6].Message, "Clean first container on third run")
-	assert.Equal(t, "Trying to delete container: 9cd87474be90", hook.Entries[7].Message, "Clean second container on third run")
-	assert.Equal(t, "Trying to delete image: 8dfafdbc3a40", hook.Entries[8].Message, "Clean third container on third run")
-	assert.Equal(t, "Trying to delete image: 9cd87474be90", hook.Entries[9].Message, "Clean fourth container on third run")
+	assert.Equal(t, "Trying to delete container: 3176a2479c92", hook.Entries[2].Message, "clean 12h old image")
+	assert.Equal(t, "Trying to delete container: 4cb07b47f9fb", hook.Entries[3].Message, "clean five minutes old image")
+	assert.Equal(t, "Trying to delete image: 3176a2479c92", hook.Entries[4].Message, "clean old image")
+	assert.Equal(t, "Trying to delete image: 4cb07b47f9fb", hook.Entries[5].Message, "Clean old image")
+	assert.Equal(t, "Trying to delete image: 5c76a2479c92", hook.Entries[6].Message, "Clean old image")
+	assert.Equal(t, "Cleaning all images/containers", hook.Entries[7].Message, "start of third")
+	assert.Equal(t, "Trying to delete container: 9cd87474be90", hook.Entries[8].Message, "Clean old container")
+	assert.Equal(t, "Trying to delete container: 3176a2479c92", hook.Entries[9].Message, "Clean old container")
 }
 
 func TestStatsdReporting(t *testing.T) {
 	_, hook := logrustest.NewNullLogger()
 	log.AddHook(hook)
+
+	server := testServer(generateTestData())
+	defer server.Close()
 
 	statsdAddress := "127.0.0.1:6667"
 
@@ -242,25 +278,11 @@ func TestStatsdReporting(t *testing.T) {
 	os.Unsetenv("TESTMODE")
 
 	keepLastData := 0 * time.Second // Delete all images
-	tenMinuteOld := time.Now().Add(-10 * time.Minute)
 
-	// Two entities to be cleaned up
-	body := `[
-     {
-             "Id": "8dfafdbc3a40",
-             "Created": ` + strconv.FormatInt(tenMinuteOld.Unix(), 10) + `
-     },
-     {
-             "Id": "9cd87474be90",
-             "Created": ` + strconv.FormatInt(tenMinuteOld.Unix(), 10) + `
-     }
-  ]`
-
-	Client = newTestClient(&FakeRoundTripper{message: body, status: http.StatusOK})
+	StartDockerClient(server.URL)
 
 	expectedContainerMessages := []string{
-		"test.dockergc.container.amount:2|g",
-		"test.dockergc.container.deleted:1|c",
+		"test.dockergc.container.dead.amount:4|g",
 		"test.dockergc.container.deleted:1|c",
 	}
 	udp.ShouldReceiveAll(t, expectedContainerMessages, func() {
@@ -268,8 +290,7 @@ func TestStatsdReporting(t *testing.T) {
 	})
 
 	expectedImageMessages := []string{
-		"test.dockergc.image.amount:2|g",
-		"test.dockergc.image.deleted:1|c",
+		"test.dockergc.image.amount:5|g",
 		"test.dockergc.image.deleted:1|c",
 	}
 	udp.ShouldReceiveAll(t, expectedImageMessages, func() {
@@ -283,29 +304,18 @@ func TestMonitorDiskSpace(t *testing.T) {
 	_, hook := logrustest.NewNullLogger()
 	log.AddHook(hook)
 
-	timeNow := time.Now()
+	server := testServer(generateTestData())
+	defer server.Close()
 
-	var arrayOfData []string
-	for i := 0; i < 100; i++ {
-		data := `
-     {
-             "Id": "8dfafdbc3a0` + strconv.Itoa(i) + `",
-             "Created": ` + strconv.FormatInt(timeNow.Unix()-int64(i), 10) + `
-     }`
-		arrayOfData = append(arrayOfData, data)
-	}
-
-	body := strings.Join(arrayOfData[:], ",")
-	body = `[` + body + "\n" + `  ]`
-
-	Client = newTestClient(&FakeRoundTripper{message: body, status: http.StatusOK})
+	Client = nil
+	StartDockerClient(server.URL)
 
 	fakeDiskSpaceFetcher := &FakeDiskSpaceFetcher{}
 
 	CleanAllWithDiskSpacePolicy(fakeDiskSpaceFetcher, GCPolicy{HighDiskSpaceThreshold: 6, LowDiskSpaceThreshold: 3})
 
 	// Assert that we see 6*10 delete runs for images + 6x100 (all) container deletes + 6*2 info messages (counting down from 9 to 4)
-	assert.Equal(t, 672, len(hook.Entries), "We see 672 message")
+	assert.Equal(t, 66, len(hook.Entries), "We see 67 message")
 	assert.Equal(t, log.InfoLevel, hook.Entries[0].Level, "We should report starting of cleanup based on threshold")
 	assert.Equal(t, "Cleaning images to reach low used disk space threshold", hook.Entries[0].Message, "report low image threshold reached")
 }


### PR DESCRIPTION
- Make container deletion use the exited date rather than created
- Refactor testdata to be more consistent by using custom HTTP server that handles routes
