### PR TITLE
Filter out used images based on running containers before deleting

### DIFF
--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -xe
 
-TESTMODE=true gb test -v ./...
+TESTMODE=true gb test -v ./... "$@"

--- a/src/pkg/gc/gc_test.go
+++ b/src/pkg/gc/gc_test.go
@@ -1,7 +1,6 @@
 package gc
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -30,35 +29,44 @@ func (d *FakeDiskSpaceFetcher) GetUsedDiskSpaceInPercents() (int, error) {
 	return d.counter, nil
 }
 
-var responseIndices = map[string]int{}
+type testResponseMap map[string]map[string]string
 
-type testResponseMap map[string][]string
-
-func testServer(responses testResponseMap) *httptest.Server {
+func testServer(routes testResponseMap) *httptest.Server {
 	mux := http.NewServeMux()
 
-	for path, responses := range responses {
+	for path, responses := range routes {
 		// Variable shadowing.
 		_responses := responses
-
 		fun := func(w http.ResponseWriter, r *http.Request) {
-			idx := responseIndices[path]
-			response := _responses[idx%len(_responses)]
-			responseIndices[path] = idx + 1
-
 			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(response))
+			found := false
+			reqParameters := r.URL.Query()
+
+			for parameter, response := range _responses {
+				parameterAndValue := strings.SplitN(parameter, "=", 2)
+				// first index is the param and second value eg. ..yourthing?foo=bar, 0 = foo, 1 = bar
+				foundParameterValue := strings.Join(reqParameters[parameterAndValue[0]], ",")
+
+				//Check that we have a value for the param and that the found param is the same we have specified
+				if len(parameterAndValue) > 1 && foundParameterValue == parameterAndValue[1] {
+					found = true
+					w.Write([]byte(response))
+					break
+				}
+			}
+			//If no param was matched use default (and check that it was specified)
+			if !found && len(_responses["default"]) > 0 {
+				w.Write([]byte(_responses["default"]))
+			}
 		}
-
-		mux.Handle(path, http.HandlerFunc(fun))
+		mux.HandleFunc(path, fun)
 	}
-
 	server := httptest.NewServer(mux)
 	return server
 }
 
-func generateFourTestImages() string {
+func generateFiveTestImages() (string, map[string]string) {
 	//Generate 4 images which 2 have been exited in past minute and two havent
 	timeNow := time.Now()
 	threeSecondsOld := timeNow.Add(-3 * time.Second)
@@ -74,6 +82,7 @@ func generateFourTestImages() string {
 	idsAndDatesMap["5c76a2479c92"] = strconv.FormatInt(dayOld.Unix(), 10)
 
 	var imageList []string
+	imageHistoryList := make(map[string]string)
 
 	for id, date := range idsAndDatesMap {
 		imageListInfo := `
@@ -82,15 +91,25 @@ func generateFourTestImages() string {
              "Created":` + date + `
      }`
 		imageList = append(imageList, imageListInfo)
+		imageHistory := `
+	 [{
+             "Id":"` + id + `",
+             "Created":` + date + `,
+             "Tags": [
+                "test:` + id + `"
+             ]
+	 }]`
+
+		imageHistoryList[id] = imageHistory
 	}
 
 	imageListAsJson := strings.Join(imageList[:], ",")
 	imageListAsJson = `[` + imageListAsJson + "\n" + `  ]`
 
-	return imageListAsJson
+	return imageListAsJson, imageHistoryList
 }
 
-func generateFourTestContainers() (string, map[string]string) {
+func generateFiveTestContainers() (string, map[string]string) {
 	//Generate 4 containers of which 2 have been exited in past minute and two havent
 	timeNow := time.Now()
 	fiveMinutesOld := timeNow.Add(-3 * time.Second)
@@ -102,6 +121,7 @@ func generateFourTestContainers() (string, map[string]string) {
 	idsAndDatesMap["9cd87474be90"] = fiveMinutesOld.Format(time.RFC3339)
 	idsAndDatesMap["3176a2479c92"] = twelweHoursOld.Format(time.RFC3339)
 	idsAndDatesMap["4cb07b47f9fb"] = weekOld.Format(time.RFC3339)
+	idsAndDatesMap["5c76a2479c92"] = weekOld.Format(time.RFC3339)
 
 	var containerList []string
 	containerListWithFullData := make(map[string]string)
@@ -109,7 +129,8 @@ func generateFourTestContainers() (string, map[string]string) {
 	for id, date := range idsAndDatesMap {
 		containerListInfo := `
      {
-             "Id":"` + id + `"
+             "Id":"` + id + `",
+             "Image":"` + id + `"
      }`
 		containerList = append(containerList, containerListInfo)
 
@@ -132,27 +153,33 @@ func generateFourTestContainers() (string, map[string]string) {
 }
 
 func generateTestData() testResponseMap {
-	imageListAsJson := generateFourTestImages()
-	containerListAsJson, containerListWithFullData := generateFourTestContainers()
+	imageListAsJson, imageHistoryList := generateFiveTestImages()
+	containerListAsJson, containerListWithFullData := generateFiveTestContainers()
 
 	responses := testResponseMap{
-		"/_ping":           []string{`OK`},
-		"/images/":         []string{`OK`},
-		"/images/json":     []string{imageListAsJson},
-		"/containers/json": []string{containerListAsJson},
+		"/_ping":       map[string]string{"default": "OK"},
+		"/images/json": map[string]string{"all=1": imageListAsJson},
+		"/containers/json": map[string]string{"default": containerListAsJson,
+			"filters={\"status\":[\"running\"]}":          "[]",
+			"filters={\"status\":[\"exited\", \"dead\"]}": containerListAsJson},
 	}
 
 	for id, data := range containerListWithFullData {
-		responses["/containers/"+id+"/json"] = []string{data}
-		responses["/containers/"+id+""] = []string{"ok"}
+		responses["/containers/"+id+"/json"] = map[string]string{"default": data}
+		responses["/containers/"+id+""] = map[string]string{"default": "OK"}
+	}
+
+	for id, data := range imageHistoryList {
+		responses["/images/"+id+""] = map[string]string{"default": "OK"}
+		responses["/images/"+id+"/history"] = map[string]string{"default": data}
 	}
 
 	return responses
 }
 
 func TestStartDockerClient(t *testing.T) {
-	responses := map[string][]string{
-		"/_ping": []string{"OK"},
+	responses := map[string]map[string]string{
+		"/_ping": {"default": "OK"},
 	}
 
 	server := testServer(responses)
@@ -169,7 +196,6 @@ func TestFailIfDockerNotAvailable(t *testing.T) {
 
 	// Pattern from https://talks.golang.org/2014/testing.slide#1
 	if os.Getenv("BE_CRASHER") == "1" {
-		fmt.Println("DEBUG2")
 		endpoint := "unix:///var/run/missing_docker.sock"
 		StartDockerClient(endpoint)
 		return
@@ -222,11 +248,13 @@ func TestCleanContainers(t *testing.T) {
 	CleanContainers(keepLastContainers)
 
 	// Verify 2 images (12h + week old) were cleaned
-	assert.Equal(t, 2, len(hook.Entries), "we should be removing two images")
+	assert.Equal(t, 3, len(hook.Entries), "we should be removing two images")
 	assert.Equal(t, log.InfoLevel, hook.Entries[0].Level, "all image removal messages should log on Info level")
-	assert.Equal(t, "Trying to delete container: 4cb07b47f9fb", hook.Entries[1].Message, "expected to delete 8dbd9e392a964c")
+	assert.Equal(t, "Trying to delete container: 3176a2479c92", hook.Entries[0].Message, "expected to delete 3176a2479c92")
 	assert.Equal(t, log.InfoLevel, hook.Entries[1].Level, "all image removal messages should log on Info level")
-	assert.Equal(t, "Trying to delete container: 3176a2479c92", hook.Entries[0].Message, "expected to delete 8dbd9e392a964c")
+	assert.Equal(t, "Trying to delete container: 4cb07b47f9fb", hook.Entries[1].Message, "expected to delete 4cb07b47f9fb")
+	assert.Equal(t, log.InfoLevel, hook.Entries[2].Level, "all image removal messages should log on Info level")
+	assert.Equal(t, "Trying to delete container: 5c76a2479c92", hook.Entries[2].Message, "expected to delete 8dbd9e392a964c")
 }
 
 func TestContinuousGC(t *testing.T) {
@@ -250,18 +278,18 @@ func TestContinuousGC(t *testing.T) {
 	StopGC()
 
 	// Assert all that is expected to happen during that 10s period
-	assert.Equal(t, 25, len(hook.Entries), "We see 25 message")
+	assert.Equal(t, 28, len(hook.Entries), "We see 28 message")
 	assert.Equal(t, log.InfoLevel, hook.Entries[0].Level, "We should use see Info about starting continuous GC")
 	assert.Equal(t, "Continous run started in timebased mode with interval (in seconds): 3", hook.Entries[0].Message, "report start of GC")
 	assert.Equal(t, "Cleaning all images/containers", hook.Entries[1].Message, "report start of first cleanup")
 	assert.Equal(t, "Trying to delete container: 3176a2479c92", hook.Entries[2].Message, "clean 12h old image")
 	assert.Equal(t, "Trying to delete container: 4cb07b47f9fb", hook.Entries[3].Message, "clean five minutes old image")
-	assert.Equal(t, "Trying to delete image: 3176a2479c92", hook.Entries[4].Message, "clean old image")
-	assert.Equal(t, "Trying to delete image: 4cb07b47f9fb", hook.Entries[5].Message, "Clean old image")
-	assert.Equal(t, "Trying to delete image: 5c76a2479c92", hook.Entries[6].Message, "Clean old image")
-	assert.Equal(t, "Cleaning all images/containers", hook.Entries[7].Message, "start of third")
-	assert.Equal(t, "Trying to delete container: 9cd87474be90", hook.Entries[8].Message, "Clean old container")
-	assert.Equal(t, "Trying to delete container: 3176a2479c92", hook.Entries[9].Message, "Clean old container")
+	assert.Equal(t, "Trying to delete container: 5c76a2479c92", hook.Entries[4].Message, "Clean old container")
+	assert.Equal(t, "Trying to delete image: 3176a2479c92", hook.Entries[5].Message, "clean old image")
+	assert.Equal(t, "Trying to delete image: 4cb07b47f9fb", hook.Entries[6].Message, "Clean old image")
+	assert.Equal(t, "Cleaning all images/containers", hook.Entries[8].Message, "start of third")
+	assert.Equal(t, "Trying to delete container: 9cd87474be90", hook.Entries[9].Message, "Clean old container")
+	assert.Equal(t, "Trying to delete container: 3176a2479c92", hook.Entries[10].Message, "Clean old container")
 }
 
 func TestStatsdReporting(t *testing.T) {
@@ -282,7 +310,7 @@ func TestStatsdReporting(t *testing.T) {
 	StartDockerClient(server.URL)
 
 	expectedContainerMessages := []string{
-		"test.dockergc.container.dead.amount:4|g",
+		"test.dockergc.container.dead.amount:5|g",
 		"test.dockergc.container.deleted:1|c",
 	}
 	udp.ShouldReceiveAll(t, expectedContainerMessages, func() {
@@ -314,8 +342,8 @@ func TestMonitorDiskSpace(t *testing.T) {
 
 	CleanAllWithDiskSpacePolicy(fakeDiskSpaceFetcher, GCPolicy{HighDiskSpaceThreshold: 6, LowDiskSpaceThreshold: 3})
 
-	// Assert that we see 6*10 delete runs for images + 6x100 (all) container deletes + 6*2 info messages (counting down from 9 to 4)
-	assert.Equal(t, 66, len(hook.Entries), "We see 67 message")
+	// Assert that we see 5*10 delete runs for images + 5x100 (all) container deletes + 6*2 info messages (counting down from 9 to 4)
+	assert.Equal(t, 72, len(hook.Entries), "We see 72 message")
 	assert.Equal(t, log.InfoLevel, hook.Entries[0].Level, "We should report starting of cleanup based on threshold")
 	assert.Equal(t, "Cleaning images to reach low used disk space threshold", hook.Entries[0].Message, "report low image threshold reached")
 }

--- a/src/pkg/helpers/helpers.go
+++ b/src/pkg/helpers/helpers.go
@@ -1,0 +1,26 @@
+package helpers
+
+import (
+	"sort"
+
+	"github.com/cznic/sortutil"
+)
+
+func StringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+func SortDataMap(dataMap map[int64][]string) []int64 {
+	//Sort map based on dates to make order predictable
+	var dates []int64
+	for k := range dataMap {
+		dates = append(dates, k)
+	}
+	sort.Sort(sort.Reverse(sortutil.Int64Slice(dates)))
+	return dates
+}


### PR DESCRIPTION
- When deleting containers only try to delete containers that have exited (Dead/Exited)
- When deleting images we first filter out images that are attached to running containers
- When deleting images don't try to delete the whole hierarchy. This is useful in cases where the baseimage etc is used even if top layer isn't used anymore
- Remove force delete from image removal. It should not be needed
- Separate generic things from `gc.go` to `helpers.go`
- Improve tests to handle query params being supplied to Docker ( like filtering container lists based on status etc)

@andremedeiros 
