### PR TITLE
Check called HTTP endpoints in GC tests

### DIFF
--- a/src/pkg/gc/gc.go
+++ b/src/pkg/gc/gc.go
@@ -119,12 +119,12 @@ func CleanAllWithDiskSpacePolicy(diskSpaceFetcher DiskSpace, policy GCPolicy) {
 	}
 }
 
-func CleanImages(ttl time.Duration) {
-	removeDataBasedOnAge(getImages(), Image, ttl)
+func CleanImages(ttl time.Duration) int {
+	return removeDataBasedOnAge(getImages(), Image, ttl)
 }
 
-func CleanContainers(ttl time.Duration) {
-	removeDataBasedOnAge(getFinishedContainers(), Container, ttl)
+func CleanContainers(ttl time.Duration) int {
+	return removeDataBasedOnAge(getFinishedContainers(), Container, ttl)
 }
 
 func CleanAll(mode string, policy GCPolicy) (int, int) {


### PR DESCRIPTION
- Check for amount of deleted data based on counters in `gc_test.go`
- Add support for HTTP Methods in the dummy docker API server (eg. distinguish between `DELETE` and `GET`)
- Track called endpoints for checking that we called the right ones during execution
- Add type `httpMethodAndResponseMap` and `parameterAndResponseMap` to make the testdata a bit more readable

@andremedeiros @grollest
