### PR TITLE
Continue through the whole image list in batch deletion mode

### DIFF
--- a/src/pkg/helpers/helpers.go
+++ b/src/pkg/helpers/helpers.go
@@ -16,11 +16,23 @@ func StringInSlice(a string, list []string) bool {
 }
 
 func SortDataMap(dataMap map[int64][]string) []int64 {
-	//Sort map based on dates to make order predictable
-	var dates []int64
+	//Sort map keys to make order predictable for indexing
+	keys := getKeysFromMap(dataMap)
+	sort.Sort(sortutil.Int64Slice(keys))
+	return keys
+}
+
+func SortDataMapReverse(dataMap map[int64][]string) []int64 {
+	//Sort map keys to make order predictable for indexing (REVERSE)
+	keys := getKeysFromMap(dataMap)
+	sort.Sort(sort.Reverse(sortutil.Int64Slice(keys)))
+	return keys
+}
+
+func getKeysFromMap(dataMap map[int64][]string) []int64 {
+	var keys []int64
 	for k := range dataMap {
-		dates = append(dates, k)
+		keys = append(keys, k)
 	}
-	sort.Sort(sort.Reverse(sortutil.Int64Slice(dates)))
-	return dates
+	return keys
 }


### PR DESCRIPTION
There was a bug in the original implementation of this where we gave up if we didn't delete anything in the last run. The problem with that is that cleaner only goes through 10 images at a time, and might give up if those 10 couldn't be removed. The correct behaviour of course is to go through the list and give up after that.

**Changes**
- Remove the "give up if nothing is deleted" since it doesn't actually make sense
- Move the `for` loop in to `batch` -mode so we can continue going through the whole imagelist and only give up if theres enough disk space (or we've gone through the list)
- Improve logging in the sense that we now also report the end of the run with how many images/containers were deleted and what is the disk space usage at that point
- Improve testing around this to actually test the case where we have cleaned enough to find the correct threshold
- Improve testing a bit so we can create x*5 amount of containers or images and them being unique (id and timewise)

**Fuckyness/considerations**
Nothing I can think of, this is the behaviour that was intended originally

@andremedeiros @grollest
